### PR TITLE
Fix the typo on dependency name

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 paho-mqtt==1.5.1
 PyYAML==5.4.1
-request==2.25.0
+requests==2.26


### PR DESCRIPTION
The module "requests" in requirements.txt had a typo. Just fixed it and updated the version to latest stable version. 